### PR TITLE
added a config option to reduce the number of full_node worker processes to reduce ram usage

### DIFF
--- a/olive/consensus/blockchain.py
+++ b/olive/consensus/blockchain.py
@@ -35,6 +35,8 @@ from olive.util.errors import Err
 from olive.util.generator_tools import get_block_header, tx_removals_and_additions
 from olive.util.ints import uint16, uint32, uint64, uint128
 from olive.util.streamable import recurse_jsonify
+from olive.util.default_root import DEFAULT_ROOT_PATH
+from olive.util.config import load_config
 
 log = logging.getLogger(__name__)
 
@@ -101,7 +103,10 @@ class Blockchain(BlockchainInterface):
         cpu_count = multiprocessing.cpu_count()
         if cpu_count > 61:
             cpu_count = 61  # Windows Server 2016 has an issue https://bugs.python.org/issue26903
+        config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
         num_workers = max(cpu_count - 2, 1)
+        if 'multiprocessing_limit' in config.keys():
+            num_workers = min(num_workers, int(config["multiprocessing_limit"]));
         self.pool = ProcessPoolExecutor(max_workers=num_workers)
         log.info(f"Started {num_workers} processes for block validation")
 

--- a/olive/util/initial-config.yaml
+++ b/olive/util/initial-config.yaml
@@ -7,6 +7,12 @@ daemon_port: 56309
 inbound_rate_limit_percent: 100
 outbound_rate_limit_percent: 30
 
+# Limit the number of start_full_node worker processes to reduce ram and cpu usage
+# This allows users to farm more forks without running out of ram
+# Setting this too low reduces sync speed, but a synced node can stay synced with a multiprocessing_limit of 2
+# A value higher than 61 takes no effect, as chia limits the workers to 61 (windows server related python bug)
+# multiprocessing_limit: 4
+
 network_overrides: &network_overrides
   constants:
     mainnet:


### PR DESCRIPTION
The Issue:
The biggest problem chia fork farmers face is ram usage. Many farmers simply do not have the ram required to run all the forks and my 64GB machine is at its limits as well

One Cause:
By default, chia and its forks create number of logical cores - 2 start_full_node process. Each worker process takes 50MB RAM. On a typical 8 core, 16 threads CPU this is 700MB of RAM per chia fork. For 38 Forks this is about 26GB of ram for the full_nodes alone

One Solution:
Give farmers the ability to limit the number of worker processes. Make this configurable, so pure, designated full_nodes can still use all cpu cores for their task, but allow farmers to reduce the CPU and RAM load of running a full_node

Pro:
- On an 8 core / 16 thread cpu this can easily save up to 600MB RAM per fork
- On an 32 core / 64 thread cpu this can easily save 3GB RAM per fork
- The ram saving is especially noticable on dual core machines, which likely have little ram available
- Users can choose to reduce ram usage, which allows them to farm more forks including yours if they there previously unable to

Cons:
Reducing the number of worker processes can reduce sync speed. This does not affect ongoing synchronization of synced nodes, only a node that is way behind the chain really benefits from many worker processes. The user has full control over that and can reduce the number of worker processes once synced or set them to a good compromise between resource consumption and sync speed, tailored for his machine

Changes:
- 5 Lines of code (two of those line are imports). In a place where the chia team already limits the number of worker processes to 61 I added a config check and apply the configured limit if one is set
- 1 new config option in config.yaml

Who is effected by this change:
- This change only effects users who add the config option `multiprocessing_limit` to their config.yaml
